### PR TITLE
Ribbonsampletest

### DIFF
--- a/Examples/WiderRibbonDemo/Models/GeneralSettings.cs
+++ b/Examples/WiderRibbonDemo/Models/GeneralSettings.cs
@@ -1,0 +1,37 @@
+﻿using Prism.Ioc;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using Wider.Core.Services;
+using Wider.Core.Settings;
+using Xceed.Wpf.Toolkit.PropertyGrid.Attributes;
+
+namespace WiderRibbonDemo.Models
+{
+    class GeneralSettings : AbstractSettings
+    {
+        private readonly IThemeManager _themeManager;
+
+        public GeneralSettings(IThemeManager themeManager)
+        {
+            _themeManager = themeManager;
+        }
+
+        [UserScopedSetting()]
+        [DefaultSettingValue("Default")]
+        [Category("Colors")]
+        [DisplayName("Theme Style")]
+        [Description("The background color of the text editor")]
+        [ItemsSource(typeof(ThemeItemSource))]
+        public String SelectedTheme
+        {
+            get => _themeManager.Current.Name;
+            set => _themeManager.SetCurrent(value);
+        }
+    }
+}

--- a/Examples/WiderRibbonDemo/Models/SettingsItem.cs
+++ b/Examples/WiderRibbonDemo/Models/SettingsItem.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wider.Core.Settings;
+
+namespace WiderRibbonDemo.Models
+{
+    class SettingsItem : AbstractSettingsItem
+    {
+        public SettingsItem(String title, AbstractSettings settings) : base(title, settings) { }
+    }
+}

--- a/Examples/WiderRibbonDemo/Models/TestShape.cs
+++ b/Examples/WiderRibbonDemo/Models/TestShape.cs
@@ -171,6 +171,17 @@ namespace WiderRibbonDemo.Models
                                 VerticalAlignment = VerticalAlignment.Center,
                                 HorizontalAlignment = HorizontalAlignment.Center
                             };
+
+                            // Testing for BoundsChanged event.
+                            b.MouseRightButtonDown += (s, e) =>
+                            {
+                                _bounds = new Rect(
+                                    Bounds.X + 10,
+                                    Bounds.Y + 10,
+                                    b.Width,
+                                    b.Height);
+                                BoundsChanged?.Invoke(this, null);
+                            };
                             b.Child = text;
                             b.Background = Fill;
                             //DropShadowBitmapEffect effect = new DropShadowBitmapEffect();

--- a/Examples/WiderRibbonDemo/Models/ThemeItemSource.cs
+++ b/Examples/WiderRibbonDemo/Models/ThemeItemSource.cs
@@ -1,0 +1,18 @@
+﻿using Xceed.Wpf.Toolkit.PropertyGrid.Attributes;
+
+namespace WiderRibbonDemo.Models
+{
+    internal class ThemeItemSource : IItemsSource
+    {
+        public ItemCollection GetValues()
+        {
+            return new ItemCollection
+            {
+                "Default",
+                "Light",
+                "Dark",
+                "Blue",
+            };
+        }
+    }
+}

--- a/Examples/WiderRibbonDemo/Models/Workspace.cs
+++ b/Examples/WiderRibbonDemo/Models/Workspace.cs
@@ -21,7 +21,7 @@ namespace WiderRibbonDemo.Models
         private VirtualCanvasViewModel _canvasViewModel;
         private readonly ISettingsManager _settingsManager;
         private readonly IThemeSettings _themeSettings;
-        private readonly IThemeManager _themneManager;
+        private readonly IThemeManager _themeManager;
 
         public VirtualCanvasViewModel CanvasViewModel
         {
@@ -29,7 +29,11 @@ namespace WiderRibbonDemo.Models
             set => SetProperty(ref _canvasViewModel, value);
         }
 
-        public ICommand OpenCanvasCommand => new DelegateCommand(() => OpenAndFocus<VirtualCanvasViewModel>());
+        public ICommand OpenCanvasCommand => new DelegateCommand(() =>
+        {
+            CanvasViewModel = OpenAndFocus<VirtualCanvasViewModel>();
+            CanvasViewModel.IsClosing += (s, e) => CanvasViewModel = null;
+        });
 
         public ICommand TaskRunCommand => new DelegateCommand(() => OpenAndFocus<TaskRunTestsViewModel>());
 
@@ -53,7 +57,7 @@ namespace WiderRibbonDemo.Models
         {
             _settingsManager = Container.Resolve<ISettingsManager>();
             _themeSettings = Container.Resolve<IThemeSettings>();
-            _themneManager = Container.Resolve<IThemeManager>();
+            _themeManager = Container.Resolve<IThemeManager>();
 
             // Setup theme
             String themeName = _themeSettings.SelectedTheme;
@@ -61,19 +65,18 @@ namespace WiderRibbonDemo.Models
             {
                 themeName = _themeSettings.GetSystemTheme();
             }
-            _themneManager.SetCurrent(themeName);
+            _themeManager.SetCurrent(themeName);
 
             // Setup settings
-            
             _settingsManager.Add(new SettingsItem("General", Container.Resolve<GeneralSettings>()));
         }
 
-        public IEnumerable<String> ThemeList => _themneManager.Themes.Select(x => x.Name);
+        public IEnumerable<String> ThemeList => _themeManager.Themes.Select(x => x.Name);
 
         public String SelectedTheme
         {
-            set => _themneManager.SetCurrent(value);
-            get => _themneManager.Current.Name;
+            set => _themeManager.SetCurrent(value);
+            get => _themeManager.Current.Name;
         }
     }
 }

--- a/Examples/WiderRibbonDemo/Models/Workspace.cs
+++ b/Examples/WiderRibbonDemo/Models/Workspace.cs
@@ -19,6 +19,7 @@ namespace WiderRibbonDemo.Models
     {
         // Handles data context for ribbon.
         private VirtualCanvasViewModel _canvasViewModel;
+        private readonly ISettingsManager _settingsManager;
         private readonly IThemeSettings _themeSettings;
         private readonly IThemeManager _themneManager;
 
@@ -31,6 +32,8 @@ namespace WiderRibbonDemo.Models
         public ICommand OpenCanvasCommand => new DelegateCommand(() => OpenAndFocus<VirtualCanvasViewModel>());
 
         public ICommand TaskRunCommand => new DelegateCommand(() => OpenAndFocus<TaskRunTestsViewModel>());
+
+        public ICommand SettingsCommand => _settingsManager.SettingsCommand;
 
         private T OpenAndFocus<T>() where T : ContentViewModel
         {
@@ -48,16 +51,21 @@ namespace WiderRibbonDemo.Models
 
         public Workspace(IContainerExtension container) : base(container)
         {
+            _settingsManager = Container.Resolve<ISettingsManager>();
             _themeSettings = Container.Resolve<IThemeSettings>();
             _themneManager = Container.Resolve<IThemeManager>();
 
-
+            // Setup theme
             String themeName = _themeSettings.SelectedTheme;
             if (themeName == "Default")
             {
                 themeName = _themeSettings.GetSystemTheme();
             }
             _themneManager.SetCurrent(themeName);
+
+            // Setup settings
+            
+            _settingsManager.Add(new SettingsItem("General", Container.Resolve<GeneralSettings>()));
         }
 
         public IEnumerable<String> ThemeList => _themneManager.Themes.Select(x => x.Name);

--- a/Examples/WiderRibbonDemo/ViewModels/VirtualCanvasViewModel.cs
+++ b/Examples/WiderRibbonDemo/ViewModels/VirtualCanvasViewModel.cs
@@ -71,7 +71,7 @@ namespace WiderRibbonDemo.ViewModels
             }
         });
 
-        public ICommand RowColChange => new DelegateCommand<Object>((x) => 
+        public ICommand RowColChange => new DelegateCommand<Object>((x) =>
         {
             Int32 value = Int32.Parse(x.ToString());
             rows = cols = value;
@@ -84,7 +84,8 @@ namespace WiderRibbonDemo.ViewModels
             {
                 ResetZoom();
             }
-            else {
+            else
+            {
                 Double value = Double.Parse(x);
                 Zoom.Zoom = value / 100;
                 _statusbarService.Text = $"Zoom is {value}";
@@ -141,7 +142,7 @@ namespace WiderRibbonDemo.ViewModels
             Zoom.Zoom = 1;
             Zoom.Offset = new Point(0, 0);
 
-            // Fill a sparse grid of rectangular color palette nodes with each tile being 50x30.    
+            // Fill a sparse grid of rectangular color palette nodes with each tile being 50x30.
             // with hue across x-axis and saturation on y-axis, brightness is fixed at 100;
             Random r = new Random(Environment.TickCount);
             Graph.VirtualChildren.Clear();
@@ -160,7 +161,7 @@ namespace WiderRibbonDemo.ViewModels
                                     r.Next((Int32)_tileHeight, (Int32)_tileHeight * 5));
                 TestShapeType type = (TestShapeType)r.Next(0, (Int32)TestShapeType.Last);
 
-                //Color color = HlsColor.ColorFromHLS((x * 240) / cols, 100, 240 - ((y * 240) / rows));                    
+                //Color color = HlsColor.ColorFromHLS((x * 240) / cols, 100, 240 - ((y * 240) / rows));
                 TestShape shape = new TestShape(new Rect(pos, s), type, r);
                 SetRandomBrushes(shape, r);
                 Graph.AddVirtualChild(shape);

--- a/Examples/WiderRibbonDemo/ViewModels/VirtualCanvasViewModel.cs
+++ b/Examples/WiderRibbonDemo/ViewModels/VirtualCanvasViewModel.cs
@@ -2,18 +2,13 @@
 using Prism.Commands;
 using Prism.Ioc;
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using Wider.Content.VirtualCanvas.Controls;
-using Wider.Content.VirtualCanvas.Gestures;
-using Wider.Content.VirtualCanvas.Models;
 using Wider.Core.Services;
 using WiderRibbonDemo.Extensions;
 using WiderRibbonDemo.Models;
@@ -38,6 +33,8 @@ namespace WiderRibbonDemo.ViewModels
         private Boolean _showGridLines;
         private readonly Polyline _gridLines = new Polyline();
         private readonly IStatusbarService _statusbarService;
+
+        public EventHandler IsClosing;
 
         public Boolean ShowContextRibbon => true;
 
@@ -169,6 +166,12 @@ namespace WiderRibbonDemo.ViewModels
                 Graph.AddVirtualChild(shape);
                 count--;
             }
+        }
+
+        protected override void Close(Object obj)
+        {
+            IsClosing?.Invoke(this, null);
+            base.Close(obj);
         }
 
         private readonly String[] _colorNames = new String[10];

--- a/Examples/WiderRibbonDemo/Views/MainRibbon.xaml
+++ b/Examples/WiderRibbonDemo/Views/MainRibbon.xaml
@@ -28,6 +28,13 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <fluent:Ribbon>
+        <fluent:Ribbon.Menu>
+            <fluent:Backstage>
+                <fluent:BackstageTabControl>
+                    <fluent:Button Header="Settings" Command="{Binding SettingsCommand}"/>
+                </fluent:BackstageTabControl>
+            </fluent:Backstage>
+        </fluent:Ribbon.Menu>
         <fluent:Ribbon.ContextualGroups>
             <!-- This will give our context menu a green look -->
             <fluent:RibbonContextualTabGroup x:Name="canvasGroup" Header="Virtual Canvas" Visibility="Visible" Background="Green" BorderBrush="Green" />

--- a/Examples/WiderRibbonDemo/WiderRibbonDemo.csproj
+++ b/Examples/WiderRibbonDemo/WiderRibbonDemo.csproj
@@ -59,9 +59,12 @@
     <Compile Include="Extensions\QuadrantExtension.cs" />
     <Compile Include="Extensions\QuadTreeExtension.cs" />
     <Compile Include="Models\EmptyModel.cs" />
+    <Compile Include="Models\GeneralSettings.cs" />
     <Compile Include="Models\HlsColor.cs" />
     <Compile Include="Models\LogWriter.cs" />
+    <Compile Include="Models\SettingsItem.cs" />
     <Compile Include="Models\TestShape.cs" />
+    <Compile Include="Models\ThemeItemSource.cs" />
     <Compile Include="ViewModels\TaskRunTestsViewModel.cs" />
     <Compile Include="ViewModels\VirtualCanvasViewModel.cs" />
     <Compile Include="Views\TaskRunTests.xaml.cs">

--- a/Modules/Wider.Content.VirtualCanvas/Controls/VirtualCanvas.cs
+++ b/Modules/Wider.Content.VirtualCanvas/Controls/VirtualCanvas.cs
@@ -20,6 +20,7 @@ using System.Xml;
 using System.Globalization;
 using Wider.Content.VirtualCanvas.Gestures;
 using Wider.Content.VirtualCanvas.Models;
+using System.Linq;
 
 namespace Wider.Content.VirtualCanvas.Controls
 {
@@ -282,38 +283,35 @@ namespace Wider.Content.VirtualCanvas.Controls
                 Double.IsNaN(Extent.Width) || Double.IsNaN(Extent.Height))
             {
                 rebuild = true;
-                Boolean first = true;
-                Rect extent = new Rect();
                 _visualPositions = new Dictionary<IVirtualChild, Int32>();
+
+                //Boolean first = true;
                 Int32 index = 0;
                 foreach (IVirtualChild c in _children)
                 {
                     _visualPositions[c] = index++;
 
+                    // Sanity check
                     Rect childBounds = c.Bounds;
                     if (childBounds.Width != 0 && childBounds.Height != 0)
                     {
                         if (Double.IsNaN(childBounds.Width) || Double.IsNaN(childBounds.Height))
                         {
-                            throw new InvalidOperationException(String.Format(System.Globalization.CultureInfo.CurrentUICulture,
+                            throw new InvalidOperationException(String.Format(CultureInfo.CurrentUICulture,
                                 "Child type '{0}' returned NaN bounds", c.GetType().Name));
-                        }
-                        if (first)
-                        {
-                            extent = childBounds;
-                            first = false;
-                        }
-                        else
-                        {
-                            extent = Rect.Union(extent, childBounds);
                         }
                     }
                 }
-                Extent = extent.Size;
+
+                // Get extents
+                Extent = new Size(
+                    _children.Max(x => x.Bounds.Right),
+                    _children.Max(x => x.Bounds.Bottom));
+
                 // Ok, now we know the size we can create the index.
                 Index = new QuadTree<IVirtualChild>
                 {
-                    Bounds = new Rect(0, 0, extent.Width, extent.Height)
+                    Bounds = new Rect(0, 0, Extent.Width, Extent.Height)
                 };
                 foreach (IVirtualChild n in _children)
                 {

--- a/Modules/Wider.Content.VirtualCanvas/Controls/VirtualCanvas.cs
+++ b/Modules/Wider.Content.VirtualCanvas/Controls/VirtualCanvas.cs
@@ -301,6 +301,12 @@ namespace Wider.Content.VirtualCanvas.Controls
                                 "Child type '{0}' returned NaN bounds", c.GetType().Name));
                         }
                     }
+
+                    // This is an expensive solution, need to re-visit this later.
+                    c.BoundsChanged += (s, e) =>
+                    {
+                        RebuildVisuals();
+                    };
                 }
 
                 // Get extents


### PR DESCRIPTION
Fix some issues with test not showing groping tab, and now possible to move child item and reflect in VirtualCanvas. This is an expensive operation, and will need to be optimized in the future.